### PR TITLE
Fix DisplayOption type issue

### DIFF
--- a/src/custom-element.ts
+++ b/src/custom-element.ts
@@ -1,7 +1,6 @@
 import { CLASSES } from './css-classes';
 import { fetchData, PerkGridFetchError } from './fetch-data';
-import { render, RenderOptions, ResizeEvent } from './render';
-import { DisplayOption } from './render/types';
+import { render, DisplayOption, RenderOptions, ResizeEvent } from './render';
 import { PerkGridTypeError } from './types/utils';
 import { createElement } from './utils/dom';
 
@@ -304,4 +303,4 @@ if (customElements.get('perk-grid')) {
 
 export * from './css-classes';
 // eslint-disable-next-line unicorn/prefer-export-from
-export { ResizeEvent };
+export { ResizeEvent, DisplayOption };

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -4,7 +4,8 @@ import { createElement } from '../utils/dom';
 import enableKeyboardNav from './enable-keyboard-nav';
 import { makeResponsive, ResizeEvent } from './make-responsive';
 import { body, footer, header } from './nodes';
-import { DisplayOption } from './types';
+
+export type DisplayOption = 'responsive' | 'grid' | 'list';
 
 export interface RenderOptions {
   /**

--- a/src/render/nodes.ts
+++ b/src/render/nodes.ts
@@ -1,7 +1,8 @@
 import { CLASSES } from '../css-classes';
 import { EventData, Package, Perk } from '../types/data';
 import { createElement } from '../utils/dom';
-import { DisplayOption } from './types';
+
+type DisplayOption = 'responsive' | 'grid' | 'list';
 
 type NodeOptions = {
   display: DisplayOption;

--- a/src/render/types.d.ts
+++ b/src/render/types.d.ts
@@ -1,1 +1,0 @@
-export type DisplayOption = 'responsive' | 'grid' | 'list';


### PR DESCRIPTION
Fixes this error for apps that use this library:

```
../event-perk-grid/dist/render/index.d.ts:3:31 - error TS2307: Cannot find module './types' or its corresponding type declarations.

3 import { DisplayOption } from './types';
```